### PR TITLE
Update: curate, config.yaml, and remove rename_json

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,11 @@
+# ID for analyses: accession or strain
+id_field: "accession"
+
+# Config parameters related to the curate rule
+curate:
+  # List of date fields to standardize to ISO format YYYY-MM-DD
+  date_fields: ["collection_date"]
+  # List of expected date formats that are present in the date fields provided above
+  # These date formats should use directives expected by datetime
+  # See https://docs.python.org/3.9/library/datetime.html#strftime-and-strptime-format-codes
+  expected_date_formats: ['%Y', '%m.%Y', '%d.%m.%Y', "%b-%Y", "%d-%b-%Y","%Y-%m-%d"]

--- a/genome/config/auspice_config.json
+++ b/genome/config/auspice_config.json
@@ -67,8 +67,12 @@
     "color_by": "clade_membership",
     "geo_resolution": "country",
     "distance_measure": "num_date",
+    "tip_label": "strain",
     "map_triplicate": true
   },
+  "metadata_columns": [
+    "strain"
+  ],
   "filters": [
     "country",
     "author"

--- a/protein_xy/config/auspice_config.json
+++ b/protein_xy/config/auspice_config.json
@@ -67,8 +67,12 @@
     "color_by": "clade_membership",
     "geo_resolution": "country",
     "distance_measure": "num_date",
+    "tip_label": "strain",
     "map_triplicate": true
   },
+  "metadata_columns": [
+    "strain"
+  ],
   "filters": [
     "country",
     "author"


### PR DESCRIPTION
- simplified the `curate` rule
- added a global `config.yaml` file
- removed the `rename_json` rule
    - redundant, auspice config default: `tip_label = "strain"`